### PR TITLE
fix: include all items from kern.disks -n split

### DIFF
--- a/salt/grains/disks.py
+++ b/salt/grains/disks.py
@@ -72,7 +72,7 @@ def _freebsd_disks():
     devices = __salt__['cmd.run']('{0} -n kern.disks'.format(sysctl))
     SSD_TOKEN = 'non-rotating'
 
-    for device in devices.split(' ')[1:]:
+    for device in devices.split(' '):
         if device.startswith('cd'):
             log.debug('Disk grain skipping cd')
         elif _freebsd_vbox():


### PR DESCRIPTION
salt['grains.get']('disks') always dropped the last disk (first in returned list from sysctl).
"sysctl -n" does not include sysctl-name, so the [1:] offset was wrong.